### PR TITLE
Add more tags to PrimaryTagChoose blacklist

### DIFF
--- a/src/SteamApp/PrimaryTagChooser.php
+++ b/src/SteamApp/PrimaryTagChooser.php
@@ -13,11 +13,19 @@ final class PrimaryTagChooser
     use StaticClass;
 
     private const BLACKLIST = [
+        'Co-op',
+        'Dark Humor',
         'Early Access',
+        'Female Protagonist',
         'Free to Play',
+        'Great Soundtrack',
         'Indie',
         'Multiplayer',
+        'Nudity',
+        'Pixel Graphics',
         'RPGMaker',
+        'Sexual Content',
+        'Singleplayer',
         'VR',
     ];
 


### PR DESCRIPTION
All taken from chosen primary tags used on the site as of the time of this commit, except for "Singleplayer" which just seems like a natural addition next to "Multiplayer" and "Co-op".

Expanding on the list introduced with https://github.com/250/Steam-Top-250/issues/10 / commit 8f41e2b48a024f3c395e0847579f1c2f5069ccd6.

Some other tags I noted but ended up not including in this PR: Story Rich, Zombies, Difficult, Sci-fi, Anime, Space, Cute, Comedy, Open World.